### PR TITLE
Replace base::filter with stats::filter in conflict_prefer documentation

### DIFF
--- a/R/prefer.R
+++ b/R/prefer.R
@@ -2,7 +2,7 @@
 #'
 #' `conflict_prefer()` allows you to declare "winners" of conflicts.
 #' You can either declare a specific pairing (i.e. `dplyr::filter()` beats
-#' `base::filter()`), or an overall winner (i.e. `dplyr::filter()` beats
+#' `stats::filter()`), or an overall winner (i.e. `dplyr::filter()` beats
 #' all comers).
 #'
 #' @section Best practices:
@@ -20,8 +20,8 @@
 #' conflict_prefer("filter", "dplyr")
 #'
 #' # Prefer over specified package or packages
-#' conflict_prefer("filter", "dplyr", "base")
-#' conflict_prefer("filter", "dplyr", c("base", "filtration"))
+#' conflict_prefer("filter", "dplyr", "stats")
+#' conflict_prefer("filter", "dplyr", c("stats", "filtration"))
 conflict_prefer <- function(name, winner, losers = NULL, quiet = FALSE) {
   stopifnot(is.character(name), length(name) == 1)
   stopifnot(is.character(winner), length(winner) == 1)

--- a/man/conflict_prefer.Rd
+++ b/man/conflict_prefer.Rd
@@ -19,7 +19,7 @@ If omitted, \code{winner} will beat all comers.}
 \description{
 \code{conflict_prefer()} allows you to declare "winners" of conflicts.
 You can either declare a specific pairing (i.e. \code{dplyr::filter()} beats
-\code{base::filter()}), or an overall winner (i.e. \code{dplyr::filter()} beats
+\code{stats::filter()}), or an overall winner (i.e. \code{dplyr::filter()} beats
 all comers).
 }
 \section{Best practices}{
@@ -33,6 +33,6 @@ script, immediately underneath the relevant \code{library()} call.
 conflict_prefer("filter", "dplyr")
 
 # Prefer over specified package or packages
-conflict_prefer("filter", "dplyr", "base")
-conflict_prefer("filter", "dplyr", c("base", "filtration"))
+conflict_prefer("filter", "dplyr", "stats")
+conflict_prefer("filter", "dplyr", c("stats", "filtration"))
 }


### PR DESCRIPTION
Hello! This is my first time contributing to this package. Thank you, it's very useful!

When I viewed the help for `conflict_prefer` I was confused because `base::filter` does not exist. There is a `base::Filter` with a capital "F" but I guess `stats::filter` makes more sense here.