### PR TITLE
WIP: Tweaks to `conflict_prefer_all()`

### DIFF
--- a/R/prefer.R
+++ b/R/prefer.R
@@ -91,7 +91,13 @@ conflict_prefer_matching <- function(pattern, winner, losers = NULL, quiet = FAL
 #' @export
 #' @rdname conflict_prefer
 conflict_prefer_all <- function(winner, losers = NULL, quiet = FALSE) {
-  names <- sort(pkg_ls(winner))
+  winner_names <- sort(pkg_ls(winner))
+  if (is.null(losers)) {
+    names <- winner_names
+  } else {
+    conflicts <- conflict_scout(c(winner, losers))
+    names <- intersect(winner_names, names(conflicts))
+  }
   names <- losers_intersect(names, losers)
 
   for (name in names) {

--- a/tests/testthat/_snaps/prefer.md
+++ b/tests/testthat/_snaps/prefer.md
@@ -19,6 +19,7 @@
     Code
       conflict_prefer_all("funmatch")
     Message
+      [conflicted] Will prefer funmatch::mean over any other package.
       [conflicted] Will prefer funmatch::median over any other package.
       [conflicted] Will prefer funmatch::pi over any other package.
 
@@ -27,12 +28,13 @@
     Code
       conflict_prefer_all("funmatch", "base")
     Message
-      [conflicted] Will prefer funmatch::pi over base::pi.
+      [conflicted] Will prefer funmatch::mean over base::mean.
 
 ---
 
     Code
       conflict_prefer_matching("m", "funmatch")
     Message
+      [conflicted] Will prefer funmatch::mean over any other package.
       [conflicted] Will prefer funmatch::median over any other package.
 

--- a/tests/testthat/funmatch/NAMESPACE
+++ b/tests/testthat/funmatch/NAMESPACE
@@ -1,2 +1,3 @@
 export(pi)
 export(median)
+export(mean)

--- a/tests/testthat/funmatch/R/test.R
+++ b/tests/testthat/funmatch/R/test.R
@@ -1,3 +1,5 @@
 median <- 10
 
 pi <- function() 3
+
+mean <- function() "mean"

--- a/tests/testthat/test-prefer.R
+++ b/tests/testthat/test-prefer.R
@@ -48,18 +48,18 @@ test_that("can register preference for multiple functions", {
   expect_snapshot({
     conflict_prefer_all("funmatch")
   })
-  expect_setequal(prefs_ls(), c("median", "pi"))
+  expect_setequal(prefs_ls(), c("mean", "median", "pi"))
   prefs_reset()
 
   expect_snapshot({
     conflict_prefer_all("funmatch", "base")
   })
-  expect_setequal(prefs_ls(), "pi")
+  expect_setequal(prefs_ls(), "mean")
   prefs_reset()
 
   expect_snapshot({
     conflict_prefer_matching("m", "funmatch")
   })
-  expect_setequal(prefs_ls(), "median")
+  expect_setequal(prefs_ls(), c("median", "mean"))
   prefs_reset()
 })


### PR DESCRIPTION
Generally, should this function use a little more care when determining the losers, in particular with `losers = NULL` ?